### PR TITLE
add List and forEach support, improve set convertion

### DIFF
--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -242,14 +242,7 @@ proto.toParse = function (obj) {
      body: [ [Object], [Object], [Object] ] } }
 */
 proto.toForeach = function (obj) {
-  if (obj.left.type === 'Reference' && obj.right.type === 'Reference') {
-    var r = '{% for ' + obj.left.object.name + ' in ' + obj.right.object.name + ' %}' +
-            this.to(obj.body) + '{% endfor %}';
-  } else if (obj.left.type === 'Reference' && obj.right.type === 'List') {
-    var r = '{% for ' + obj.left.object.name + ' in ' + this._toObjectString(obj.right) + ' %}' +
-            this.to(obj.body) + '{% endfor %}';
-  } else {
-    throw new Error('未考虑完全的Foreach');
-  }
-  return r;
+  return '{% for ' + obj.left.object.name + ' in ' +
+         (obj.right.type === 'Reference' ? obj.right.object.name : this._toObjectString(obj.right)) +
+         ' %}' + this.to(obj.body) + '{% endfor %}';
 };

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -242,7 +242,14 @@ proto.toParse = function (obj) {
      body: [ [Object], [Object], [Object] ] } }
 */
 proto.toForeach = function (obj) {
-  var r =  '{% for ' + obj.left.object.name + ' in ' + obj.right.object.name + ' %}' +
-         this.to(obj.body) + '{% endfor %}';
+  if (obj.left.type === 'Reference' && obj.right.type === 'Reference') {
+    var r = '{% for ' + obj.left.object.name + ' in ' + obj.right.object.name + ' %}' +
+            this.to(obj.body) + '{% endfor %}';
+  } else if (obj.left.type === 'Reference' && obj.right.type === 'List') {
+    var r = '{% for ' + obj.left.object.name + ' in ' + this._toObjectString(obj.right) + ' %}' +
+            this.to(obj.body) + '{% endfor %}';
+  } else {
+    throw new Error('未考虑完全的Foreach');
+  }
   return r;
 };

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -111,7 +111,7 @@ proto._toObjectString = function (obj) {
     var arr = obj.elements.map(function (v) {
       return this._toObjectString(v);
     }, this);
-    return '[' + arr.join(',') + ']';
+    return 'VelocityArray(' + arr.join(', ') + ')';
   } else {
     return String(obj.value);
   }

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -107,6 +107,11 @@ proto._toObjectString = function (obj) {
       right = '(' + right + ')';
     }
     return out + right;
+  } else if (obj.type === 'List') {
+    var arr = obj.elements.map(function (v) {
+      return this._toObjectString(v);
+    }, this);
+    return '[' + arr.join(',') + ']';
   } else {
     return String(obj.value);
   }
@@ -148,7 +153,7 @@ proto.toAssignExpr = function (expr) {
     for (var i = 0; i <= last; i++) {
       var part = ast.body[i];
       if (part.type === 'Text') {
-        var text = "'" + part.value + "'";
+        var text = "'" + part.value.replace(/'|"/g, '\\$&') + "'";
         if (i > 0) {
           text = ' + ' + text;
         }
@@ -218,4 +223,26 @@ proto.toMacroCall = function (obj) {
 
 proto.toParse = function (obj) {
   return '{% include ' + this._toObjectString(obj.argument) + ' %}';
+};
+
+/*
+{ type: 'Foreach',
+  pos: { first_line: 33, last_line: 45, first_column: 6, last_column: 10 },
+  left:
+   { type: 'Reference',
+     pos: { first_line: 33, last_line: 33, first_column: 15, last_column: 20 },
+     object: { type: 'Identifier', pos: [Object], name: 'item' } },
+  right:
+   { type: 'Reference',
+     pos: { first_line: 33, last_line: 33, first_column: 24, last_column: 37 },
+     object: { type: 'Identifier', pos: [Object], name: 'productsList' } },
+  body:
+   { type: 'Statements',
+     pos: { first_line: 33, last_line: 45, first_column: 38, last_column: 6 },
+     body: [ [Object], [Object], [Object] ] } }
+*/
+proto.toForeach = function (obj) {
+  var r =  '{% for ' + obj.left.object.name + ' in ' + obj.right.object.name + ' %}' +
+         this.to(obj.body) + '{% endfor %}';
+  return r;
 };

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -168,6 +168,11 @@ proto.toAssignExpr = function (expr) {
       if (part.type === 'Reference') {
         part = part.object;
       }
+
+      // for eaxample, #set($a="$b")
+      // In some cases, right side only contains one reference like the example above. To deal with situations like this,
+      // we should convent the variable to string to invoke toString method. This is very important.
+      if (ast.body.length === 1) out += "\'\' + ";
       out += this._toObjectString(part);
     }
   } else {

--- a/test/nunjucks.test.js
+++ b/test/nunjucks.test.js
@@ -47,6 +47,7 @@ describe('nunjucks.test.js', function () {
     vmto.nunjucks('#set( $a = $b )').should.equal('{% set a = b %}');
     vmto.nunjucks('#set( $a = ["a", "b"] )').should.equal('{% set a = [\'a\',\'b\'] %}');
     vmto.nunjucks('#set( $a = "<a href=\'/url\'>some test</a>" )').should.equal('{% set a = \'<a href=\\\'/url\\\'>some test</a>\' %}');
+    vmto.nunjucks('#set( $a = "$b" )').should.equal('{% set a = \'\' + b %}');
   });
 
   it('should convert Reference => Method', function () {

--- a/test/nunjucks.test.js
+++ b/test/nunjucks.test.js
@@ -45,6 +45,8 @@ describe('nunjucks.test.js', function () {
     vmto.nunjucks('#set($a = \'foo\')').should.equal('{% set a = \'foo\' %}');
     vmto.nunjucks('#set($a = $b)').should.equal('{% set a = b %}');
     vmto.nunjucks('#set( $a = $b )').should.equal('{% set a = b %}');
+    vmto.nunjucks('#set( $a = ["a", "b"] )').should.equal('{% set a = [\'a\',\'b\'] %}');
+    vmto.nunjucks('#set( $a = "<a href=\'/url\'>some test</a>" )').should.equal('{% set a = \'<a href=\\\'/url\\\'>some test</a>\' %}');
   });
 
   it('should convert Reference => Method', function () {
@@ -185,5 +187,12 @@ describe('nunjucks.test.js', function () {
 
     vmto.nunjucks("hello, $!name!", opt).should.equal('hello, {{name | safe}}!');
     vmto.nunjucks("hello, $!{name}!", opt).should.equal('hello, {{name | safe}}!');
+  });
+
+  it('should convert foreach', function() {
+    vmto.nunjucks('#foreach($item in ["a", "b"])$item#end')
+      .should.equal('{% for item in [\'a\',\'b\'] %}{{item}}{% endfor %}');
+    vmto.nunjucks('#foreach($item in $somelist)$item#end')
+      .should.equal('{% for item in somelist %}{{item}}{% endfor %}');
   });
 });

--- a/test/nunjucks.test.js
+++ b/test/nunjucks.test.js
@@ -45,7 +45,7 @@ describe('nunjucks.test.js', function () {
     vmto.nunjucks('#set($a = \'foo\')').should.equal('{% set a = \'foo\' %}');
     vmto.nunjucks('#set($a = $b)').should.equal('{% set a = b %}');
     vmto.nunjucks('#set( $a = $b )').should.equal('{% set a = b %}');
-    vmto.nunjucks('#set( $a = ["a", "b"] )').should.equal('{% set a = [\'a\',\'b\'] %}');
+    vmto.nunjucks('#set( $a = ["a", "b"] )').should.equal('{% set a = VelocityArray(\'a\', \'b\') %}');
     vmto.nunjucks('#set( $a = "<a href=\'/url\'>some test</a>" )').should.equal('{% set a = \'<a href=\\\'/url\\\'>some test</a>\' %}');
     vmto.nunjucks('#set( $a = "$b" )').should.equal('{% set a = \'\' + b %}');
   });
@@ -192,7 +192,7 @@ describe('nunjucks.test.js', function () {
 
   it('should convert foreach', function() {
     vmto.nunjucks('#foreach($item in ["a", "b"])$item#end')
-      .should.equal('{% for item in [\'a\',\'b\'] %}{{item}}{% endfor %}');
+      .should.equal('{% for item in VelocityArray(\'a\', \'b\') %}{{item}}{% endfor %}');
     vmto.nunjucks('#foreach($item in $somelist)$item#end')
       .should.equal('{% for item in somelist %}{{item}}{% endfor %}');
   });


### PR DESCRIPTION
1. 增加list支持 `#set($a=["a", "b"])`
2. 增加foreach支持 `#foreach($item in ["a", "b"]` `#foreach($item in $somelist)$item#end`
3. 增强set，防止set中有引号时导致不闭合。能够处理 `#set( $a = "<a href='url'>some test</a>" )`